### PR TITLE
Add Ruby Functions Framework Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ The Function Framework is currently implemented for these runtimes:
 - [Go](https://github.com/GoogleCloudPlatform/functions-framework-go)
 - [PHP](https://github.com/GoogleCloudPlatform/functions-framework-php)
 - [Python](https://github.com/GoogleCloudPlatform/functions-framework-python)
+- [Ruby](https://github.com/GoogleCloudPlatform/functions-framework-ruby)
 
 These languages do not have complete Function Frameworks. You can upvote tracking issues here:
 
 - [Java](https://github.com/GoogleCloudPlatform/functions-framework/issues/4)
-- [Ruby](https://github.com/GoogleCloudPlatform/functions-framework/issues/7)
 - [.NET](https://github.com/GoogleCloudPlatform/functions-framework/issues/8)
 
 ## Specification


### PR DESCRIPTION
Adds the Ruby FF to the list of released frameworks.