### PR TITLE
Add Traceparent Param for CloudEvent Signature to FF Contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Your function have must use the following signature:
 
 The developer's function must either explicitly or implicitly signal that it has completed performing useful work. The function may explicitly signal this condition by explicitly returning. The function may implicitly signal this condition by simply evaluating until it reaches the end of the function's code block.
 
+#### Traceparent Header
+
+In addition to the standard CloudEvent properties, the framework **may** add a `traceparent` property to the `cloudevent` object, following the [Distributed Tracing extension](https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md). This value for this property is retrieved from the HTTP header name: `traceparent`.
+
 ### Legacy Events (Signature Type: `event`)
 
 The Functions Framework **may** support signature type `events`. This signature supports non-CloudEvent style events. Your function have must use the following signature:

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ The developer's function must either explicitly or implicitly signal that it has
 
 In addition to the standard CloudEvent properties, the framework **may** add a `traceparent` property to the `cloudevent` object, following the [Distributed Tracing extension](https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md). This value for this property is retrieved from the HTTP header name: `traceparent`.
 
+More about the `traceparent` header can be read in [W3C Trace Content docs](https://w3c.github.io/trace-context/).
+
 ### Legacy Events (Signature Type: `event`)
 
 The Functions Framework **may** support signature type `events`. This signature supports non-CloudEvent style events. Your function have must use the following signature:


### PR DESCRIPTION
Adds option for Function Frameworks to expose `traceparent` header in CloudEvent signatures.

Read more about the difference between `traceparent` and `x-cloud-trace-context` here: https://cloud.google.com/endpoints/docs/openapi/tracing#supported_headers

And more about the CE extension mentioning `traceparent` here:
https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md

Fixes: https://github.com/GoogleCloudPlatform/functions-framework/issues/47

R: @squee1945 @mtraver 