### PR TITLE
docs: add declarative function's framework signature configuration to FF contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ This configuration may be provided implicitly or explicitly. In some languages, 
 
 The framework may, for developer convenience, provide multiple mechanisms (for example, environment variables, command-line arguments, configuration files) for developers to specify configuration. If multiple methods are provided, the order of precedence must be the following:
 
-- Source code configurations
-- Command-line flags
-- Environment variables
+1. Source code configurations
+1. Command-line flags
+1. Environment variables
 
 ## Observability
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,17 @@ Legend:
 
 ## Specification Summary
 
-A Functions Framework instantiates web server and invokes function code in response to an HTTP request (`http`) or CloudEvent request (`cloudevent`) depending on the function's signature type. A Functions Framework may optionally support functions with signature type `event` for legacy-style events.
+A Functions Framework instantiates web server and invokes function code in response to an **HTTP** or **CloudEvent** request depending on the function's signature type. A Functions Framework may also optionally support functions with signature type `event` for legacy-style events.
 
 The Functions Framework library must be configurable via environment variables and may be configurable via command-line flags:
 
-Command-line flag         | Environment variable      | Description
-------------------------- | ------------------------- | -----------
-`--port`                    | `PORT`                    | The port on which the Functions Framework listens for requests. Default: `8080`
-`--target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`
-`--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `cloudevent`
+Required | Command-line flag | Environment variable | Description
+--- | --- | --- | ---
+YES | `--port` | `PORT` | The port on which the Functions Framework listens for requests. Default: `8080`
+NO | `--target` | `FUNCTION_TARGET` | The name of the exported function to be invoked in response to requests. Default: `function`
+NO | `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function for non-declarative functions. Default: `http`; accepted values: `http` or `cloudevent`
+
+The Functions Framework library may provide a declarative configuration for the function's signature type. In this case, the user will specify the signature in the function's code.
 
 > Note: `SIGNATURE_TYPE: event` supports legacy, non-CloudEvent events. Support for these event formats are not required for Function Frameworks.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Legend:
 
 ## Specification Summary
 
-A Functions Framework instantiates web server and invokes function code in response to an **HTTP** or **CloudEvent** request depending on the function's signature type. A Functions Framework may also optionally support functions with signature type `event` for legacy-style events.
+A Functions Framework instantiates web server and invokes function code in response to an **HTTP** (`http`) or **CloudEvent** (`cloudevent`) request depending on the function's signature type. A Functions Framework may also optionally support functions with signature type `event` for legacy-style events.
 
 The Functions Framework library must be configurable via environment variables and may be configurable via command-line flags:
 

--- a/README.md
+++ b/README.md
@@ -49,15 +49,13 @@ Legend:
 
 A Functions Framework instantiates web server and invokes function code in response to an **HTTP** (`http`) or **CloudEvent** (`cloudevent`) request depending on the function's signature type. A Functions Framework may also optionally support functions with signature type `event` for legacy-style events.
 
-The Functions Framework library must be configurable via environment variables and may be configurable via command-line flags:
+The Functions Framework library may be configurable via command-line flags, environment variables, or within the function code itself:
 
 Required | Command-line flag | Environment variable | Description
 --- | --- | --- | ---
 YES | `--port` | `PORT` | The port on which the Functions Framework listens for requests. Default: `8080`
-NO | `--target` | `FUNCTION_TARGET` | The name of the exported function to be invoked in response to requests. Default: `function`
-NO | `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function for non-declarative functions. Default: `http`; accepted values: `http` or `cloudevent`
-
-The Functions Framework library may provide a declarative configuration for the function's signature type. In this case, the user will specify the signature in the function's code.
+YES | `--target` | `FUNCTION_TARGET` | The name of the exported function to be invoked in response to requests. Default: `function`
+NO | `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. The Functions Framework library may provide a way to express the function signature type in code, such as through registration APIs or annotations, instead of by flag or environment variable. Default: `http`; accepted values: `http` or `cloudevent`
 
 > Note: `SIGNATURE_TYPE: event` supports legacy, non-CloudEvent events. Support for these event formats are not required for Function Frameworks.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,11 @@ The framework must allow the developer to specify (1) the port ($PORT) on which 
 
 This configuration may be provided implicitly or explicitly. In some languages, the function's signature type can be inferred by via reflection, inspecting the developer's function signatures, annotations, and exports - using language-idiomatic methods that feel natural to developers. In some languages, the signature type may need to be explicitly signalled by the developer.
 
-The framework may, for developer convenience, provide multiple mechanisms (for example, environment variables, command-line arguments, configuration files) for developers to specify configuration. If multiple methods are provided, the order of precedence must be clearly specified.
+The framework may, for developer convenience, provide multiple mechanisms (for example, environment variables, command-line arguments, configuration files) for developers to specify configuration. If multiple methods are provided, the order of precedence must be the following:
+
+- Source code configurations
+- Command-line flags
+- Environment variables
 
 ## Observability
 


### PR DESCRIPTION
- Adds the ability for a Functions Framework to implement declarative style of functions
- Removes requirement for SIGNATURE_TYPE for declarative functions

It's important to keep the main contract up-to-date for all frameworks to adhere to.

Fixes https://github.com/GoogleCloudPlatform/functions-framework/issues/53